### PR TITLE
Store current image in scene session for /images

### DIFF
--- a/src/scenes/myImages.ts
+++ b/src/scenes/myImages.ts
@@ -117,11 +117,20 @@ export const myImages = new Scenes.BaseScene<Scenes.SceneContext<ImageScene>>("m
         await getRepository(Upload).remove(ctx.scene.session.currentImage);
         ctx.scene.session.currentImage = await getImage(ctx.from.id, ctx.scene.session.skip);
 
-        await ctx.editMessageReplyMarkup({ inline_keyboard: getKeyboard(ctx).reply_markup.inline_keyboard }).catch(() => {});
+        await ctx
+            .editMessageMedia(
+                {
+                    media: ctx.scene.session.currentImage.fileID,
+                    type: "photo",
+                },
+                getKeyboard(ctx)
+            )
+            .catch(() => {});
         await ctx.answerCbQuery().catch(() => {});
     })
     .action("DELETE_IMAGE_DECLINE", async (ctx) => {
-        await ctx.scene.reenter().catch(() => {});
+        await ctx.editMessageReplyMarkup({ inline_keyboard: getKeyboard(ctx).reply_markup.inline_keyboard }).catch(() => {});
+        await ctx.answerCbQuery().catch(() => {});
     })
     .action("CHOOSE_COLLECTION", async (ctx) => {
         const currentImage = ctx.scene.session.currentImage;

--- a/src/scenes/newCollection.ts
+++ b/src/scenes/newCollection.ts
@@ -2,7 +2,11 @@ import { Scenes } from "telegraf";
 import { getRepository } from "typeorm";
 import { Collection } from "../entities/Collection";
 
-export const newCollection = new Scenes.BaseScene<Scenes.SceneContext>("createCollection")
+interface NewCollectionScene extends Scenes.SceneSessionData {
+    collectionName: string;
+}
+
+export const newCollection = new Scenes.BaseScene<Scenes.SceneContext<NewCollectionScene>>("createCollection")
     .enter((ctx) => ctx.reply("Enter the name of new collection"))
     .on("text", async (ctx) => {
         const repository = getRepository(Collection);
@@ -20,12 +24,10 @@ export const newCollection = new Scenes.BaseScene<Scenes.SceneContext>("createCo
             userID: ctx.from.id,
             isPublic: false,
         });
-        (ctx.scene.session as any).collectionName = ctx.message.text;
+        ctx.scene.session.collectionName = ctx.message.text;
 
         ctx.scene.leave().catch(() => {});
     })
     .leave((ctx) => {
-        ctx.reply(`Collection with name ${(ctx.scene.session as any).collectionName} created`).catch((err: any) =>
-            console.log("[ERROR]: ", err)
-        );
+        ctx.reply(`Collection with name ${ctx.scene.session.collectionName} created`).catch((err: any) => console.log("[ERROR]: ", err));
     });


### PR DESCRIPTION
Now current scene `image` stored in ram and shared across of actions. So you can attach current `image` in any scene.

Also reworked `DELETE_IMAGE_DECLINE` action. Now it just re-send keyboard, instead of re-enter in scene. So image will be the same, and for user nothing will be changed.

fixes #42